### PR TITLE
Fix incorrect iterator access (#122)

### DIFF
--- a/src/devkit/platform.cpp
+++ b/src/devkit/platform.cpp
@@ -92,7 +92,7 @@ ApiUrl::ApiUrl(const std::string& url) {
   }
   const auto index = path.find_last_of('@');
   _prefix = path.substr(0, index);
-  if (_prefix.back() == '/') {
+  if (!_prefix.empty() && _prefix.back() == '/') {
     _prefix.pop_back();
   }
   if (index == std::string::npos) {


### PR DESCRIPTION
MSVC shows when string is empty, (in my case before check it was '@' at the start of the string, so after substr it's empty), back() is accessing invalid iterator, so it's incorrect to dereference it.